### PR TITLE
sorted player_list for blits

### DIFF
--- a/screen.pyw
+++ b/screen.pyw
@@ -411,8 +411,8 @@ if __name__ == '__main__':
 
     def player_positioning(board_number):
         """Checks player positions & blits pieces"""
-        player_list.reverse()
-        for player in player_list:
+        blit_player_list = sorted(player_list, key=attrgetter("board_space"), reverse=True)
+        for player in blit_player_list:
             print("Board Number:", board_number)
             print("Board Space:", player.board_space)
             if board_number == 1:
@@ -425,7 +425,7 @@ if __name__ == '__main__':
                 loc = spaces_b4.get(player.board_space)
             print("Line 364:", loc)
             screen.blit(player.icon, loc)
-        player_list.reverse()
+
 
     # Main Game Loop
     def main_screen(board_number):


### PR DESCRIPTION
In the player_positions function, I removed the reversing of player list to blit. I added a blit_player_list that sorts the player list in descending order by the board_space player attribute. This ensures consistent blitting of the proper perspective of the player pieces as they lay over each other slightly at the starting inn of each board section. My hacky way before only blitted them properly on the first board section, main_screen(1).